### PR TITLE
Fix game difficulty on detail page

### DIFF
--- a/src/app/detail/detail.component.html
+++ b/src/app/detail/detail.component.html
@@ -75,7 +75,7 @@
           New graphics: {{game.newGraphics || 'N/A'}}
         </div>
         <div class="p-col">
-          Difficulty: {{game.difficulty || 'N/A'}}
+          Difficulty: {{game.difficulty.name || 'N/A'}}
         </div>
       </div>
 


### PR DESCRIPTION
Games with a difficulty render as "[object Object]", e.g. https://pkhax.com/45

I have not tested this change, nor am I an Angular dev, but looking at the API response it should work. Maybe.